### PR TITLE
Feature: Possibility to refer to URL instead of IP address

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -49,11 +49,17 @@ PORT 	  = '8000'
 autologin = 1
 
 # BASE_URL is variant use to save the format of host and port 
-BASE_URL = 'http://' + HOST + ':'+ PORT + '/'
+if PORT == '80':
+    BASE_URL = 'http://' + HOST +  '/'
+else:
+    BASE_URL = 'http://' + HOST + ':'+ PORT + '/'
 
 def __reflash_url__():
 	global BASE_URL
-	BASE_URL = 'http://' + HOST + ':'+ PORT + '/'
+	if PORT == '80':
+		BASE_URL = 'http://' + HOST +  '/'
+	else:
+		BASE_URL = 'http://' + HOST + ':'+ PORT + '/'
 
 
 def __read_auto_inf__():
@@ -138,7 +144,7 @@ class LoginScreen(QtWidgets.QDialog, Ui_Login_screen):
 		"""
 		global HOST,PORT
 		# check whether the length of input host and port is allowable
-		if 7<len(self.lEd_host.text())<16 :
+		if 7<len(self.lEd_host.text())<50 :
 			HOST = self.lEd_host.text()
 			PORT = self.lEd_port.text()
 			__reflash_url__()

--- a/client/login_screen.ui
+++ b/client/login_screen.ui
@@ -76,7 +76,7 @@
      <string notr="true">color: rgb(255, 255, 255);</string>
     </property>
     <property name="text">
-     <string>Enter Raspberry Pi's</string>
+     <string>Enter voiture's</string>
     </property>
     <property name="alignment">
      <set>Qt::AlignCenter</set>
@@ -151,7 +151,7 @@ padding:2px 4px;
 color: rgb(80, 76, 77);</string>
        </property>
        <property name="maxLength">
-        <number>15</number>
+        <number>50</number>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/client/login_screen.ui
+++ b/client/login_screen.ui
@@ -76,7 +76,7 @@
      <string notr="true">color: rgb(255, 255, 255);</string>
     </property>
     <property name="text">
-     <string>Enter voiture's</string>
+     <string>Enter Raspberry Pi's</string>
     </property>
     <property name="alignment">
      <set>Qt::AlignCenter</set>


### PR DESCRIPTION
Hello,

In my tests, I wanted to control the car through a URL hostname instead of an IP address in the client.py. 
I had to change the following:
- The user interface in  the form dir not allow that many characters. The limit was 16 (full ip address). I raised it to 50.
- The port was added no matter what, causing incorrect URLs and unreachable destinations. There is now a test to know if the ":" needs to be added after the host.

For users of this feature:
- You can test this using something like "duckdns" or "ngrok". Be careful: in order for your interface to work properly, you need 2 ports to be reachable: 8080 for the camera and 8000 for the controls.
I you use the free version of ngrok, only one port can be open at once with one URL, unless you hack it :-)
If you use duckdns, you have both ports reachable, and the interface works.
These limitations are those of your public reachable hostnames and their providers, not the code itself.

Hopefully this will be accepted, I found a use for it in my lab to remotely control my car (not in the same LAN).

Best regards,
Sofiane
